### PR TITLE
Dependant but not adjacent columns

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "typescript": "^2.0.7",
     "webpack": "^1.13.3"
   },
-  "name": "ion-multi-picker-br",
+  "name": "ion-multi-picker",
   "description": "Ion Multi Item Picker--An Ionic2 Custom Picker Component",
   "cordovaPlugins": [
     "cordova-plugin-device",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
       "locator": "ios"
     }
   ],
-  "version": "1.0.8",
+  "version": "1.0.9",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "typescript": "^2.0.7",
     "webpack": "^1.13.3"
   },
-  "name": "ion-multi-picker",
+  "name": "ion-multi-picker-br",
   "description": "Ion Multi Item Picker--An Ionic2 Custom Picker Component",
   "cordovaPlugins": [
     "cordova-plugin-device",
@@ -75,7 +75,7 @@
       "locator": "ios"
     }
   ],
-  "version": "1.0.9",
+  "version": "1.0.11",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "repository": {

--- a/src/components/multi-picker/multi-picker-options.ts
+++ b/src/components/multi-picker/multi-picker-options.ts
@@ -8,5 +8,7 @@ export interface MultiPickerOption {
 
 export interface MultiPickerColumn {
   name:string,
+  parentCol:string,
+  alias:string,
   options: MultiPickerOption[]
 }

--- a/src/components/multi-picker/multi-picker.ts
+++ b/src/components/multi-picker/multi-picker.ts
@@ -189,25 +189,27 @@ export class MultiPicker implements AfterContentInit, ControlValueAccessor, OnDe
     for (let i = 0; i < columns.length; i++) {
       let curCol: PickerColumn = columns[i];
       let parentCol: PickerColumn = this.getParentCol(i, columns);
-      let curOption: MultiPickerOption = curCol.options[curCol.selectedIndex];
-      let parentOption: MultiPickerOption = parentCol.options[parentCol.selectedIndex];
-      let selectedOptionWillChanged: boolean = false;
-      let curParentVal = this.getOptionParentValue(i, curOption);
-      if (curParentVal && curParentVal != parentOption.value) {
-        selectedOptionWillChanged = true;
-      }
-      if (selectedOptionWillChanged) {
-        curCol.options.forEach((option: MultiPickerOption, index) => {
-          let parentVal = this.getOptionParentValue(i, option);
-          option.disabled = parentVal != parentOption.value || index > curCol.options.findIndex((opt: MultiPickerOption) => this.getOptionParentValue(i, opt) == parentOption.value);
-        });
+      if (parentCol) {
+        let curOption: MultiPickerOption = curCol.options[curCol.selectedIndex];
+        let parentOption: MultiPickerOption = parentCol.options[parentCol.selectedIndex];
+        let selectedOptionWillChanged: boolean = false;
+        let curParentVal = this.getOptionParentValue(i, curOption);
+        if (curParentVal && curParentVal != parentOption.value) {
+          selectedOptionWillChanged = true;
+        }
+        if (selectedOptionWillChanged) {
+          curCol.options.forEach((option: MultiPickerOption, index) => {
+            let parentVal = this.getOptionParentValue(i, option);
+            option.disabled = parentVal != parentOption.value || index > curCol.options.findIndex((opt: MultiPickerOption) => this.getOptionParentValue(i, opt) == parentOption.value);
+          });
 
-        break;
-      } else {
-        curCol.options.forEach((option: MultiPickerOption, index) => {
-          let parentVal = this.getOptionParentValue(i, option);
-          option.disabled = parentVal != null && parentVal != parentOption.value;
-        });
+          break;
+        } else {
+          curCol.options.forEach((option: MultiPickerOption, index) => {
+            let parentVal = this.getOptionParentValue(i, option);
+            option.disabled = parentVal != null && parentVal != parentOption.value;
+          });
+        }
       }
     }
     picker.refresh();

--- a/src/components/multi-picker/multi-picker.ts
+++ b/src/components/multi-picker/multi-picker.ts
@@ -1,6 +1,6 @@
 import { AfterContentInit, Component, EventEmitter, forwardRef, HostListener, Input, OnDestroy, Optional, Output, ViewEncapsulation } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { Picker, PickerController, Form, Item } from 'ionic-angular';
+import {Picker, PickerController, Form, Item, PickerColumn} from 'ionic-angular';
 import { MultiPickerColumn, MultiPickerOption } from './multi-picker-options';
 
 export const MULTI_PICKER_VALUE_ACCESSOR: any = {
@@ -133,7 +133,10 @@ export class MultiPicker implements AfterContentInit, ControlValueAccessor, OnDe
 
     this.generate(picker);
 
-    if (this.multiPickerColumns.length > 1 && this.multiPickerColumns[1].options[0].parentVal) {
+    const someDependent = this.multiPickerColumns.find(function (col) {
+      return col.options[0].parentVal
+    });
+    if (this.multiPickerColumns.length > 1 && someDependent) {
       for (let i = 0; i < picker.getColumns().length; i++) {
         this.validate(picker);
       }
@@ -183,27 +186,27 @@ export class MultiPicker implements AfterContentInit, ControlValueAccessor, OnDe
    */
   validate(picker: Picker) {
     let columns = picker.getColumns();
-    for (let i = 1; i < columns.length; i++) {
-      let curCol = columns[i];
-      let preCol = columns[i - 1];
+    for (let i = 0; i < columns.length; i++) {
+      let curCol: PickerColumn = columns[i];
+      let parentCol: PickerColumn = this.getParentCol(i, columns);
       let curOption: MultiPickerOption = curCol.options[curCol.selectedIndex];
-      let preOption: MultiPickerOption = preCol.options[preCol.selectedIndex];
+      let parentOption: MultiPickerOption = parentCol.options[parentCol.selectedIndex];
       let selectedOptionWillChanged: boolean = false;
       let curParentVal = this.getOptionParentValue(i, curOption);
-      if (curParentVal && curParentVal != preOption.value) {
+      if (curParentVal && curParentVal != parentOption.value) {
         selectedOptionWillChanged = true;
       }
       if (selectedOptionWillChanged) {
         curCol.options.forEach((option: MultiPickerOption, index) => {
           let parentVal = this.getOptionParentValue(i, option);
-          option.disabled = parentVal != preOption.value || index > curCol.options.findIndex((opt: MultiPickerOption) => this.getOptionParentValue(i, opt) == preOption.value);
+          option.disabled = parentVal != parentOption.value || index > curCol.options.findIndex((opt: MultiPickerOption) => this.getOptionParentValue(i, opt) == parentOption.value);
         });
 
         break;
       } else {
         curCol.options.forEach((option: MultiPickerOption, index) => {
           let parentVal = this.getOptionParentValue(i, option);
-          option.disabled = parentVal != null && parentVal != preOption.value;
+          option.disabled = parentVal != null && parentVal != parentOption.value;
         });
       }
     }
@@ -216,6 +219,14 @@ export class MultiPicker implements AfterContentInit, ControlValueAccessor, OnDe
    */
   getOptionParentValue(colIndex, option) {
     return this.multiPickerColumns[colIndex].options.find(opt => opt.value == option.value).parentVal;
+  }
+
+  getParentCol(childColIndex: number, columns: PickerColumn[]): PickerColumn {
+    var parentColAlias = this.multiPickerColumns[childColIndex].parentCol;
+    if (parentColAlias)
+      return columns[this.multiPickerColumns.findIndex(col=> col.alias == parentColAlias)];
+    else
+      return columns[childColIndex - 1]
   }
 
   /**

--- a/src/pages/advanced/advanced.html
+++ b/src/pages/advanced/advanced.html
@@ -27,4 +27,8 @@
         <ion-label>Fruit Picker</ion-label>
         <ion-multi-picker id="fruit" [(ngModel)] = "fruit" item-content [multiPickerColumns]="fruits"></ion-multi-picker>
     </ion-item>
+    <ion-item>
+      <ion-label>Alias</ion-label>
+      <ion-multi-picker item-content [multiPickerColumns]="aliasColumns"></ion-multi-picker>
+    </ion-item>
 </ion-content>

--- a/src/pages/advanced/advanced.ts
+++ b/src/pages/advanced/advanced.ts
@@ -14,7 +14,7 @@ export class AdvancedExamplePage {
 	default = '1 1-2 1-2-2';
 	dependentColumns: any[];
 	independentColumns: any[];
-	cityColumns: any[];
+  aliasColumns: any[];
 	fruits: any[];
 	fruit: Fruit;
 	Fruit;
@@ -81,5 +81,26 @@ export class AdvancedExamplePage {
 		this.fruit = Fruit.Melon;
 		this.Fruit = Fruit;
 		this.fruits = convertEnumToColumn(this.Fruit);
+
+    this.aliasColumns = [
+      {
+        parentCol: 'months',
+        options: [
+          { text: '1-1', value: '1-1', parentVal: '1' },
+          { text: '1-2', value: '2-1', parentVal: '1'},
+          { text: '1-3', value: '3-1', parentVal: '1' },
+
+          { text: '2-1', value: '1-2', parentVal: '2' },
+          { text: '2-2', value: '2-2', parentVal: '2' }
+        ]
+      },
+      {
+        alias: 'months',
+        options: [
+          { text: '1', value: '1' },
+          { text: '2', value: '2' }
+        ]
+      }
+    ]
 	}
 }


### PR DESCRIPTION
[Ionic DateTime component](http://ionicframework.com/docs/v2/api/components/datetime/DateTime/) is awful when there is need to validate dates and time. ion-multi-picker allow to us to validate its easy but a developer cant use dependant columns in custom way. He can use it only left-to-right.
E.g.: I need to use 3 columns in this way: days, months and years, but days depends on months and years,  and I have to use a way: years, months, days, that is not correct in my case.
So, aliases and parentCol attributes fixes it