### PR TITLE
Pass `disabled` option to Picker column

### DIFF
--- a/src/components/multi-picker/multi-picker.ts
+++ b/src/components/multi-picker/multi-picker.ts
@@ -61,7 +61,7 @@ export class MultiPicker implements AfterContentInit, ControlValueAccessor, OnDe
   @Input() multiPickerColumns: MultiPickerColumn[] = [];
 
   /**
-   * @input {string} the character to separate values from different columns 
+   * @input {string} the character to separate values from different columns
    */
   @Input() separator: string = ' ';
 
@@ -202,7 +202,7 @@ export class MultiPicker implements AfterContentInit, ControlValueAccessor, OnDe
       // Generate picker column
       let column: any = {
         name: col.name || index.toString(),
-        options: options.map(option => { return { text: option.text, value: option.value, disabled: false } }),
+        options: options.map(option => { return { text: option.text, value: option.value, disabled: option.disabled || false } }),
         columnWidth: col.columnWidth
       }
       // Set selectedIndex
@@ -264,7 +264,7 @@ export class MultiPicker implements AfterContentInit, ControlValueAccessor, OnDe
   }
 
   /**
-   * Get the parentCol for a column 
+   * Get the parentCol for a column
    */
   getParentCol(childColIndex: number, columns: PickerColumn[]): PickerColumn {
     // Get the child column's position in the sequence array


### PR DESCRIPTION
Currently in the options column passed to the Ionic base picker, disabled is set to false. The documentation for this project says that disabled can be included in column options. This passes that option to the Ionic picker and defaults to false if not provided.

I needed this for another project so I didn't take time to write tests for this. Let me know if you need tests written and I'll get around to it.